### PR TITLE
Scrub request headers

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -24,6 +24,7 @@ var SETTINGS = {
     name: 'node_rollbar',
     version: exports.VERSION
   },
+  scrubHeaders: ['cookie'],
   scrubFields: ['passwd', 'password', 'secret', 'confirm_password', 'password_confirmation']
 };
 
@@ -234,7 +235,6 @@ function buildServerData() {
   return data;
 }
 
-
 function buildRequestData(req) {
   var host = req.headers.host || '<no host>';
   var proto = req.protocol || req.socket.encrypted ? 'https' : 'http';
@@ -243,7 +243,7 @@ function buildRequestData(req) {
   var data = {url: reqUrl,
               GET: parsedUrl.query,
               user_ip: extractIp(req),
-              headers: req.headers,
+              headers: scrubRequestHeaders(req.headers),
               method: req.method};
   if (req.method == 'POST') {
     var postParams = {};
@@ -252,7 +252,7 @@ function buildRequestData(req) {
         for (var k in req.body) {
           postParams[k] = req.body[k];
         }
-        data.POST = scrub_request_params(postParams);
+        data.POST = scrubRequestParams(postParams);
       } else {
         data.body = req.body;
       }
@@ -262,8 +262,20 @@ function buildRequestData(req) {
   return data;
 }
 
+function scrubRequestHeaders(headers) {
+  var obj = {};
+  for (var k in headers) {
+    if (SETTINGS.scrubHeaders.indexOf(k) == -1) {
+      obj[k] = headers[k];
+    }
+    else {
+      obj[k] = Array(headers[k].length + 1).join('*');
+    }
+  }
+  return obj;
+}
 
-function scrub_request_params(params) {
+function scrubRequestParams(params) {
   for (var k in params) {
     if (SETTINGS.scrubFields.indexOf(k) >= 0) {
       params[k] = Array(params[k].length + 1).join('*');


### PR DESCRIPTION
Removing cookie info from reportMessage and handleError by default however, this behavior is configurable by `scrubHeaders`.
