### PR TITLE
Fixed json stringifying with circular object references.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@ var url = require('url');
 var util = require('util');
 var http = require('http');
 var https = require('https');
+var stringify = require('json-stringify-safe');
 
 exports.VERSION = '1';
 exports.endpoint = 'https://api.rollbar.com/api/' + exports.VERSION + '/';
@@ -65,7 +66,7 @@ function makeApiRequest(transport, opts, bodyObj, callback) {
 
   if (bodyObj) {
     try {
-      writeData = JSON.stringify(bodyObj);
+      writeData = stringify(bodyObj);
     } catch(e) {
       return callback(e);
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "node-uuid": "1.4.x",
-    "lru-cache": "~2.2.1"
+    "lru-cache": "~2.2.1",
+    "json-stringify-safe": "~5.0.0"
   },
   "devDependencies": {
     "express": "*",


### PR DESCRIPTION
Errors caught via domains exhibit this issue.

http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json
