### PR TITLE
push frames without context on file read errors in the parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -106,7 +106,7 @@ exports.parseStack = function(stack, callback) {
                 try {
                   if (err2) {
                     console.error('could not read in file ' + frame.filename + ' for context');
-                    return looper(err2);
+                    return pendingCallback(err2);
                   } else {
                     var fileLines = fileData.split('\n');
                     cache.set(frame.filename, fileLines);
@@ -152,7 +152,7 @@ var getMultipleErrors = function(errors) {
 
   if (errors instanceof Array)
     return errors;
-  
+
   var errArray = [];
 
   for (var key in errors) {
@@ -181,7 +181,7 @@ var parseJadeDebugFrame = function(body) {
   var line;
   for (i = 0; i < numLines - 2; ++i) {
     line = lines[i];
-    jadeMatch = line.match(jadeFramePattern); 
+    jadeMatch = line.match(jadeFramePattern);
     if (jadeMatch) {
       if (jadeMatch[1] === '>') {
         contextLine = jadeMatch[2];

--- a/test/parser.js
+++ b/test/parser.js
@@ -45,6 +45,19 @@ var suite = vows.describe('parser').addBatch({
         assert.includes(lastFrame.code, 'new Error(\'Hello World\')');
       }
     }
+  },
+  'An error reading a file': {
+    topic: function(err) {
+      var exc = new Error();
+      exc.stack = "Error\n at REPLServer.self.eval (/tmp/file-does-not-exist.js:1:2)";
+      return parser.parseException(exc, this.callback);
+    },
+    'it returns frames without context': function(err, parsedObj) {
+      assert.equal(parsedObj.frames.length, 1);
+      assert.equal(parsedObj.frames[0].filename, "/tmp/file-does-not-exist.js");
+      assert.equal(parsedObj.frames[0].lineno, 1);
+      assert.equal(parsedObj.frames[0].colno, 2);
+    }
   }
 }).export(module, {error: false});
 


### PR DESCRIPTION
I think the intention on file read errors is to push the frame without context. There's a comment in the parser that says:

```
// There was an error reading the file, just push the frame and
// move on.
```

However, because `looper` was being called instead of `pendingCallback`, an error reading a file is causing rollbar to bubble the exception up through all the callbacks and never notify.
