### PR TITLE
Parse coffee script stack traces

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var lru = require('lru-cache');
 
 var linesOfContext = 3;
-var tracePattern = /^\s*at (?:([^(]+(?: \[\w\s+\])?) )?\(?(.+?)(?::(\d+):(\d+))?\)?$/;
+var tracePattern = /^\s*at (?:([^(]+(?: \[\w\s+\])?) )?\(?(.+?)(?::(\d+):(\d+)(, <js>:\d+:\d+)?)?\)?$/;
 
 var jadeTracePattern = /^\s*at .+ \(.+ (at[^)]+\))\)$/;
 var jadeFramePattern = /^\s*(>?) [0-9]+\|(\s*.+)$/m;

--- a/test/parser.js
+++ b/test/parser.js
@@ -58,6 +58,18 @@ var suite = vows.describe('parser').addBatch({
       assert.equal(parsedObj.frames[0].lineno, 1);
       assert.equal(parsedObj.frames[0].colno, 2);
     }
+  },
+  'A coffee script stacktrace': {
+    topic: function(err) {
+      var exc = new Error();
+      exc.stack = "TypeError: Cannot read property 'foo' of undefined\n at example (/tmp/example.coffee:2:3, <js>:5:20)";
+      return parser.parseException(exc, this.callback);
+    },
+    'it parses correctly': function(err, parsedObj) {
+      assert.equal(parsedObj.frames[0].filename, "/tmp/example.coffee");
+      assert.equal(parsedObj.frames[0].lineno, 2);
+      assert.equal(parsedObj.frames[0].colno, 3);
+    }
   }
 }).export(module, {error: false});
 


### PR DESCRIPTION
Coffeescript stack traces were parsing incorrectly. Before this change, for a stack trace of:

`at example (/tmp/example.coffee:2:3, <js>:5:20)`

rollbar_node thought the _filename_ was:

`/tmp/example.coffee:2:3, <js>`

I'm now stripping out the <js> part of the stacktrace entirely. It's unfortunate to lose that information, but I'm not sure if there's a way to avoid that.
