### PR TITLE
Allow addRequestData to be overridden

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -25,7 +25,8 @@ var SETTINGS = {
     version: exports.VERSION
   },
   scrubHeaders: [],
-  scrubFields: ['passwd', 'password', 'secret', 'confirm_password', 'password_confirmation']
+  scrubFields: ['passwd', 'password', 'secret', 'confirm_password', 'password_confirmation'],
+  addRequestData: addRequestData
 };
 
 var apiClient;
@@ -94,7 +95,7 @@ exports.handleError = function(err, req, callback) {
         };
 
         if (req) {
-          addRequestData(data, req);
+          SETTINGS.addRequestData(data, req);
         }
         data.server = buildServerData();
         return addItem(data, callback);
@@ -122,7 +123,7 @@ exports.reportMessageWithPayloadData = function(message, payloadData, req, callb
     };
 
     if (req) {
-      addRequestData(data, req);
+      SETTINGS.addRequestData(data, req);
     }
     data.server = buildServerData();
     return addItem(data, callback);


### PR DESCRIPTION
To allow request data to be added from non-express servers.

I use Rollbar with [Joey](https://github.com/montagejs/joey) which doesn't have the same properties available that express does, and so this lib can't get information about the request. 

By overriding `addRequestData` it's possible to add all the information needed.
