### PR TITLE
Added a logOnSuccess setting

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -10,7 +10,8 @@ exports.accessToken = null;
 var SETTINGS = {
   accessToken: null,
   protocol: 'https',
-  endpoint: exports.endpoint
+  endpoint: exports.endpoint,
+  logOnSuccess: false
 };
 
 /*
@@ -116,7 +117,7 @@ function parseApiResponse(respData, callback) {
     console.error('[Rollbar] Received error: ' + respData.message);
     return callback(new Error('Api error: ' + (respData.message || 'Unknown error')));
   } else {
-    console.log('[Rollbar] Successful api response');
+    if(SETTINGS.logOnSuccess) console.log('[Rollbar] Successful api response');
     return callback(null, respData.result);
   }
 }


### PR DESCRIPTION
On production servers the rollbar library prints out

```
[Rollbar] Successful api response
```

every time a message is successfully sent. Since overwhelmingly this is expected to succeed it seems redundant to have it in place. I've added the logOnSuccess setting (and defaulted it to false) so this is suppressed by default (and can be enabled if desired). This doesn't affect any of the existing error logging, but reduces the number of extra log lines that simply say "yes, I did what you wanted and nothing went wrong".
