### PR TITLE
do check to make sure params[k] contains a value or it will error out on...

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -310,7 +310,7 @@ function scrubRequestHeaders(headers, settings) {
 function scrubRequestParams(params, settings) {
   settings = settings || SETTINGS;
   for (var k in params) {
-    if (settings.scrubFields.indexOf(k) >= 0) {
+    if (settings.scrubFields.indexOf(k) >= 0 && params[k]) {
       params[k] = Array(params[k].length + 1).join('*');
     }
   }


### PR DESCRIPTION
... .length() check

In instances where the param's value is null, the scrubRequstParams() will error out and and rollbar will log an error that says "TypeError: Cannot read property 'length' of null" - while the true error in the application is lost.
