### PR TITLE
Added support for http proxy

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -11,7 +11,8 @@ var SETTINGS = {
   accessToken: null,
   protocol: 'https',
   endpoint: exports.endpoint,
-  verbose: true
+  verbose: true,
+  proxy: null
 };
 
 /*
@@ -30,6 +31,7 @@ exports.init = function(accessToken, options) {
   SETTINGS.endpointOpts = url.parse(exports.endpoint);
   SETTINGS.protocol = SETTINGS.endpointOpts.protocol.split(':')[0];
   SETTINGS.transport = {http: http, https: https}[SETTINGS.protocol];
+  SETTINGS.proxy = options.proxy;
 
   var portCheck = SETTINGS.endpointOpts.host.split(':');
   if (portCheck.length > 1) {
@@ -81,6 +83,14 @@ function makeApiRequest(transport, opts, bodyObj, callback) {
     opts.headers['Content-Type'] = 'application/json';
     opts.headers['Content-Length'] = Buffer.byteLength(writeData, 'utf8');
   }
+
+  if (SETTINGS.proxy) {
+    opts.path = SETTINGS.protocol + '://' + opts.host + opts.path;
+    opts.host = SETTINGS.proxy.host;
+    opts.port = SETTINGS.proxy.port;
+    transport = http;
+  }
+
   var req = transport.request(opts, function(resp) {
     var respData = [];
     resp.setEncoding('utf8');


### PR DESCRIPTION
This doesn't change the http client already being used.

Not sure what to do test wise. I've succesfully run all tests here setting my network's proxy: https://github.com/rollbar/node_rollbar/blob/master/test/notifier.js#L9. 