### PR TITLE
Bug: incorrect order of operations for protocol

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -261,7 +261,7 @@ function buildServerData() {
 function buildRequestData(req) {
   var headers = req.headers || {};
   var host = headers.host || '<no host>';
-  var proto = req.protocol || req.socket ? (req.socket.encrypted ? 'https' : 'http') : 'http';
+  var proto = req.protocol || (req.socket && req.socket.encrypted) ? 'https' : 'http';
   var reqUrl = proto + '://' + host + (req.url || '');
   var parsedUrl = url.parse(reqUrl, true);
   var data = {url: reqUrl,


### PR DESCRIPTION
Got the following error in my application:
```
Cannot read property 'encrypted' of undefined                                                                 
TypeError: Cannot read property 'encrypted' of undefined                                                      
    at buildRequestData (/api/node_modules/rollbar/lib/notifier.js:264:55)                                    
    at Object.addRequestData (/api/node_modules/rollbar/lib/notifier.js:212:17)                               
    at /api/node_modules/rollbar/lib/notifier.js:105:20                                                       
    at /api/node_modules/rollbar/lib/parser.js:41:14                                                          
    at looper (/api/node_modules/rollbar/lib/parser.js:149:14)                                                
    at pendingCallback (/api/node_modules/rollbar/lib/parser.js:144:16)                                       
    at looper (/api/node_modules/rollbar/lib/parser.js:146:14)                                                
    at pendingCallback (/api/node_modules/rollbar/lib/parser.js:144:16)                                       
    at looper (/api/node_modules/rollbar/lib/parser.js:146:14)                                                
    at pendingCallback (/api/node_modules/rollbar/lib/parser.js:144:16)  
```