### PR TITLE
Catch multiple errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ var options = {
   // Call process.exit(1) when an uncaught exception occurs but after reporting all
   // pending errors to Rollbar.
   //
-  // Default: true
+  // Default: false
   exitOnUncaughtException: true
 };
 rollbar.handleUncaughtExceptions("POST_SERVER_ITEM_ACCESS_TOKEN", options);

--- a/rollbar.js
+++ b/rollbar.js
@@ -232,19 +232,18 @@ exports.errorHandler = function(accessToken, options) {
 
 exports.handleUncaughtExceptions = function(accessToken, options) {
   /*
-   * Registers a handler for the process.uncaughtException event. The handler
-   * will immediately send the uncaught exception + all queued items to rollbar
-   * and then shut down the rollbar library via rollbar.shutdown().
+   * Registers a handler for the process.uncaughtException event.
    *
-   * If options.exitOnUncaught is set, the notifier will optionally call process.exit(1)
-   * once the rollbar items are processed.
+   * If options.exitOnUncaughtException is set to true, the notifier will
+   * immediately send the uncaught exception + all queued items to rollbar,
+   * then call process.exit(1).
    *
    * Note: The node.js authors advise against using these type of handlers.
    * More info: http://nodejs.org/api/process.html#process_event_uncaughtexception
    *
    */
 
-  // Default to exiting on uncaught exceptions unless options.exitOnUncaughtException is set
+  // Default to not exiting on uncaught exceptions unless options.exitOnUncaughtException is set.
   options = options || {};
   var exitOnUncaught = options.exitOnUncaughtException === undefined ? false : !!options.exitOnUncaughtException;
   delete options.exitOnUncaughtException;

--- a/rollbar.js
+++ b/rollbar.js
@@ -252,21 +252,25 @@ exports.handleUncaughtExceptions = function(accessToken, options) {
   exports.init(accessToken, options);
 
   if (initialized) {
-    process.once('uncaughtException', function(err) {
-      console.error('[Rollbar] Handling uncaught exception');
+    process.on('uncaughtException', function(err) {
+      console.error('[Rollbar] Handling uncaught exception.');
       console.error(err);
 
-      notifier.changeHandler('inline');
+      if (exitOnUncaught) {
+        notifier.changeHandler('inline');
+      }
+
       notifier.handleError(err, function(err) {
         if (err) {
           console.error('[Rollbar] Encountered an error while handling an uncaught exception.');
           console.error(err);
         }
-        exports.shutdown(function(e) {
-          if (exitOnUncaught) {
+
+        if (exitOnUncaught) {
+          exports.shutdown(function(e) {
             process.exit(1);
-          }
-        });
+          });
+        }
       });
     });
   } else {


### PR DESCRIPTION
Allows handleUncaughtExceptions to handle multiple errors.  Fixes #35

I tested it locally using npm link with exitOnUncaughtException set to true and false and it worked as expected in my app.

I updated the comments and README.  Note, I didn't change the default value from true to false, but the docs were incorrect https://github.com/rollbar/node_rollbar/commit/205eb73178259654f8e6c55a4b23901ba72da889#diff-9504cb41ade36b23017a3a3438b0baa2R248

