### PR TITLE
Check LRU cache for file context

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -223,7 +223,7 @@ function gatherContexts(frames, callback) {
     }
 
     function gatherContextLines(frame, callback) {
-      var lines = tempFileCache[frame.filename];
+      var lines = tempFileCache[frame.filename] || cache.get(frame.filename);
 
       if (lines) {
         extractContextLines(frame, lines);

--- a/test/parser.js
+++ b/test/parser.js
@@ -131,7 +131,10 @@ var suite = vows.describe('parser').addBatch({
     },
     'parse it with parseException': {
       topic: function (err, exc) {
-        return parser.parseException(exc, this.callback);
+        var self = this;
+        return parser.parseException(exc, function(err, parsedObj) {
+          self.callback(err, parsedObj, exc);
+        });
       },
       'verify the filename': function (err, parsedObj) {
         assert.isNull(err);
@@ -146,6 +149,16 @@ var suite = vows.describe('parser').addBatch({
         var lastFrame = parsedObj.frames[parsedObj.frames.length - 1];
         assert.isString(lastFrame.code);
         assert.includes(lastFrame.code, 'new Error(\'Hello World\')');
+      },
+      'parse the same error again': {
+        topic: function(err, parsedObj, exc) {
+          return parser.parseException(exc, this.callback);
+        },
+        'verify the context line again': function (err, parsedObj) {
+          var lastFrame = parsedObj.frames[parsedObj.frames.length - 1];
+          assert.isString(lastFrame.code);
+          assert.includes(lastFrame.code, 'new Error(\'Hello World\')');
+        }
       }
     }
   },


### PR DESCRIPTION
It would probably be better to use the LRU cache exclusively (instead of `tempFileCache`). I didn't have time to test this, but visually, it seems like that could cause problems with extremely long stack traces -- it looks like an entry could potentially be expired from the cache between the call to `shouldReadFrameFile` and the call to `gatherContextLines`.

===

The `shouldReadFrameFile` function uses the LRU cache to determine whether
the file has been cached or not, but the cached data is only read from the
closure variable `tempFileCache`.

The easiest way to see the effects of this is to report the same error twice
in a row. The first report will contain the stack annotations, but the second
report will not, since the data is contained in the LRU cache but not in
`tempFileCache`. Files contained in the LRU cache will not be annotated in any
stack trace regardless of the error.