### PR TITLE
Fix setting protocol from request

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -173,7 +173,7 @@ function buildRequestData(req) {
 
   headers = req.headers || {};
   host = headers.host || '<no host>';
-  proto = req.protocol || (req.socket && req.socket.encrypted) ? 'https' : 'http';
+  proto = req.protocol || ((req.socket && req.socket.encrypted) ? 'https' : 'http');
   reqUrl = proto + '://' + host + (req.url || '');
   parsedUrl = url.parse(reqUrl, true);
   data = {url: reqUrl,


### PR DESCRIPTION
This is currently broken in the existing gem. For example i tried to set the protocol to 'ws' and it was 'https'