### PR TITLE
Fix undefined variables when notifier is disabled

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -299,7 +299,9 @@ function addItem(item, callback) {
     if(SETTINGS.verbose){
       console.log('[Rollbar] Sending of errors is disabled');
     }
-    callback(err, data);
+    // reporting is disabled, so it's not an error
+    // let's pretend everything is fine
+    callback();
     return;
   }
 


### PR DESCRIPTION
Hi,

Here's a quick fix for disabled mode.

Example:
```javascript
rollbar.init(process.env.ROLLBAR_ACCESS_TOKEN, { enabled: false, verbose: false });
rollbar.reportMessage('hello'); // currently causes an uncaught error
```