### PR TITLE
Fix buildRequestData when req.body is a plain object

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -187,8 +187,12 @@ function buildRequestData(req) {
   if (req.body) {
     bodyParams = {};
     if (typeof req.body === 'object') {
+      var isPlainObject = typeof req.body.constructor === 'undefined';
+
       for (k in req.body) {
-        if (req.body.hasOwnProperty(k)) {
+        var hasOwnProperty = typeof req.body.hasOwnProperty === 'function' && req.body.hasOwnProperty(k);
+
+        if (hasOwnProperty || isPlainObject) {
           bodyParams[k] = req.body[k];
         }
       }

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -106,6 +106,21 @@ var suite = vows.describe('notifier').addBatch({
       assert.isNull(err);
     }
   },
+
+  'reportMessage with a req.body as a plain object': {
+    topic: function () {
+      var request = {};
+      request.body = Object.create(null);
+      request.body.foo = 'bar';
+      request.url = 'http://localhost/foo';
+      request.method = 'POST';
+
+      notifier.reportMessage('test', 'debug', request, this.callback);
+    },
+    'verify no error is returned': function (err, data, resp) {
+      assert.deepEqual(data.request.POST, {foo: 'bar'});
+    }
+  },
   'reportMessage with invalid request object': {
     topic: function () {
       notifier.reportMessage('test', 'debug', 1, this.callback);


### PR DESCRIPTION
Some libraries, like [multer](https://github.com/expressjs/multer) create `req.body` in this way:

`req.body = Object.create(null)`

In that case we cannot call `req.body.hasOwnProperty()`. In this PR we check that `req.body` has `hasOwnProperty` function or the `req.body.constructor` is undefined, so it is a plain `Object` and we
can be sure that the keys are part of the body