### PR TITLE
Log messages with debug package; remove verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,6 @@ Default: `['passwd', 'password', 'secret', 'confirm_password', 'password_confirm
 Default: `[]`
   </dd>
   
-  <dt>verbose</dt>
-  <dd>Sets whether or not to log extra info/debug messages
-  
 Default: `true`
   </dd>
 
@@ -250,6 +247,10 @@ Default: `true`
 Default: `true`
   </dd>
   </dl>
+
+### Console output
+
+To show operational messages, include `Rollbar:*` (or, for only some messages, `Rollbar:log` or `Rollbar:error`) in your `DEBUG` environment variable.
 
 
 ## Examples

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+var logger = require('./logger');
 var async = require('async');
 var url = require('url');
 var http = require('http');
@@ -17,7 +18,6 @@ var SETTINGS = {
   accessToken: null,
   protocol: 'https',
   endpoint: exports.endpoint,
-  verbose: true,
   proxy: null
 };
 
@@ -45,24 +45,24 @@ function parseApiResponse(respData, callback) {
   try {
     respData = JSON.parse(respData);
   } catch (e) {
-    console.error('[Rollbar] Could not parse api response, err: ' + e);
+    logger.error('Could not parse api response, err: ' + e);
     return callback(e);
   }
 
   if (respData.err) {
-    console.error('[Rollbar] Received error: ' + respData.message);
+    logger.error('Received error: ' + respData.message);
     return callback(new Error('Api error: ' + (respData.message || 'Unknown error')));
   }
 
 
-  if (SETTINGS.verbose && respData.result && respData.result.uuid) {
-    console.log([
-      '[Rollbar] Successful api response.',
+  if (respData.result && respData.result.uuid) {
+    logger.log([
+      'Successful api response.',
       ' Link: https://rollbar.com/occurrence/uuid/?uuid=' + respData.result.uuid
     ].join(''));
 
-  } else if (SETTINGS.verbose) {
-    console.log('[Rollbar] Successful api response');
+  } else {
+    logger.log('Successful api response');
   }
 
   callback(null, respData.result);
@@ -80,11 +80,11 @@ function makeApiRequest(transport, opts, bodyObj, callback) {
     try {
       writeData = JSON.stringify(bodyObj);
     } catch (e) {
-      console.error('[Rollbar] Could not serialize to JSON - falling back to safe-stringify');
+      logger.error('Could not serialize to JSON - falling back to safe-stringify');
       writeData = stringify(bodyObj);
     }
   } catch (e) {
-    console.error('[Rollbar] Could not safe-stringify data. Giving up');
+    logger.error('Could not safe-stringify data. Giving up');
     return callback(e);
   }
 
@@ -116,7 +116,7 @@ function makeApiRequest(transport, opts, bodyObj, callback) {
   });
 
   req.on('error', function (err) {
-    console.error('[Rollbar] Could not make request to rollbar, ' + err);
+    logger.error('Could not make request to rollbar, ' + err);
     callback(err);
   });
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,16 @@
+/*jslint devel: true, nomen: true, plusplus: true, regexp: true, indent: 2, maxlen: 100 */
+
+"use strict";
+
+var debug = require('debug');
+var name = 'Rollbar';
+
+var logger = {
+  log: debug(name + ':log'),
+  error: debug(name + ':error')
+};
+
+// Make logger.log log to stdout rather than stderr
+logger.log.log = console.log.bind(console);
+
+module.exports = logger;

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+var logger = require('./logger');
 var async = require('async');
 var http = require('http');
 var https = require('https');
@@ -31,8 +32,7 @@ var SETTINGS = {
   scrubHeaders: [],
   scrubFields: ['passwd', 'password', 'secret', 'confirm_password', 'password_confirmation'],
   addRequestData: null,  // Can be set by the user or will default to addRequestData defined below
-  enabled: true,
-  verbose: true
+  enabled: true
 };
 
 
@@ -300,9 +300,7 @@ function addItem(item, callback) {
   }
 
   if(!SETTINGS.enabled){
-    if(SETTINGS.verbose){
-      console.log('[Rollbar] Sending of errors is disabled');
-    }
+    logger.log('Sending of errors is disabled');
     // reporting is disabled, so it's not an error
     // let's pretend everything is fine
     callback();
@@ -321,7 +319,7 @@ function addItem(item, callback) {
       });
     });
   } catch (e) {
-    console.error('[Rollbar] Internal error while building payload: ' + e);
+    logger.error('Internal error while building payload: ' + e);
     callback(e);
   }
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+var logger = require('./logger');
 var async = require('async');
 var fs = require('fs');
 var lru = require('lru-cache');
@@ -175,7 +176,7 @@ function readFileLines(filename, callback) {
       return callback(null, fileLines);
     });
   } catch (e) {
-    console.log(e);
+    logger.log(e);
   }
 }
 
@@ -260,7 +261,7 @@ exports.parseException = function (exc, callback) {
     var message, ret, firstErr, jadeMatch, jadeData;
 
     if (err) {
-      console.error('could not parse exception, err: ' + err);
+      logger.error('could not parse exception, err: ' + err);
       return callback(err);
     }
     message = String(exc.message) || '<no message>';

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "node-uuid": "1.4.x",
     "lru-cache": "~2.2.1",
+    "debug": "^2.2.0",
     "json-stringify-safe": "~5.0.0",
     "async": "~1.2.1"
   },

--- a/rollbar.js
+++ b/rollbar.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+var logger = require('./lib/logger');
 var api = require('./lib/api');
 var notifier = require('./lib/notifier');
 var parser = require('./lib/parser');
@@ -84,7 +85,7 @@ exports.init = function (accessToken, options) {
   if (!initialized) {
     options = options || {};
     if (!accessToken && options.enabled !== false) {
-      console.error('[Rollbar] Missing access_token.');
+      logger.error('Missing access_token.');
       return;
     }
 
@@ -213,7 +214,7 @@ exports.errorHandler = function (accessToken, options) {
   return function (err, req, res, next) {
     var cb = function (rollbarErr) {
       if (rollbarErr) {
-        console.error('[Rollbar] Error reporting to rollbar, ignoring: ' + rollbarErr);
+        logger.error('Error reporting to rollbar, ignoring: ' + rollbarErr);
       }
       return next(err, req, res);
     };
@@ -254,13 +255,13 @@ exports.handleUncaughtExceptions = function (accessToken, options) {
 
   if (initialized) {
     process.on('uncaughtException', function (err) {
-      console.error('[Rollbar] Handling uncaught exception.');
-      console.error(err);
+      logger.error('Handling uncaught exception.');
+      logger.error(err);
 
       notifier.handleError(err, function (err) {
         if (err) {
-          console.error('[Rollbar] Encountered an error while handling an uncaught exception.');
-          console.error(err);
+          logger.error('Encountered an error while handling an uncaught exception.');
+          logger.error(err);
         }
 
         if (exitOnUncaught) {
@@ -269,7 +270,7 @@ exports.handleUncaughtExceptions = function (accessToken, options) {
       });
     });
   } else {
-    console.error('[Rollbar] Rollbar is not initialized. Uncaught exceptions will not be tracked.');
+    logger.error('Rollbar is not initialized. Uncaught exceptions will not be tracked.');
   }
 };
 


### PR DESCRIPTION
Instead of plain `console.log` and `console.error` calls, this patch adds a logger module which provides equivalent log and error functions.

These are instances of the widely-used [debug](https://github.com/visionmedia/debug) package, which automatically adds a coloured "Rollbar" prefix, and some timing information.

These messages are namespaced as Rollbar:log and Rollbar:error, and can be enabled/disabled by the user with the `DEBUG` environment variable (which can include `Rollbar:*` for all). The `verbose` option is therefore surplus and has been removed.

But note that unless the user has `*` in their `DEBUG` environment variable, the default is now to not log these console messages, which is at odds with with the previous behaviour of always logging the error messages and logging certain other messages based on the `verbose` option.