### PR TITLE
Add minimumLevel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ Default: `[]`
 Default: `true`
   </dd>
 
+  <dt>minimumLevel</dt>
+  <dd>Sets the minimum severity level of messages to report to Rollbar
+
+Default: `debug` (i.e. all messages will be sent)
+Valid levels, in order of severity: `critical`, `error`, `warning`, `info`, `debug`
+  </dd>
+
   <dt>enabled</dt>
   <dd>Sets whether reporting of errors to Rollbar is enabled
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -32,6 +32,7 @@ var SETTINGS = {
   scrubHeaders: [],
   scrubFields: ['passwd', 'password', 'secret', 'confirm_password', 'password_confirmation'],
   addRequestData: null,  // Can be set by the user or will default to addRequestData defined below
+  minimumLevel: 'debug',
   enabled: true
 };
 
@@ -295,6 +296,40 @@ function buildItemData(item, callback) {
 }
 
 
+// Is the error level of a given item greater than or equal to the configured
+// minimum level?
+function levelGteMinimum(item) {
+  var levels, messageLevel, i, length;
+
+  levels = [
+    'critical',
+    'error',
+    'warning',
+    'info',
+    'debug'
+  ];
+  messageLevel = item.payload.level === undefined ? 'error' : item.payload.level;
+
+  for (i = 0, length = levels.length; i < length; i++) {
+    if (levels[i] === messageLevel) {
+      return true;
+    }
+    if (levels[i] === SETTINGS.minimumLevel) {
+      return false;
+    }
+  }
+
+  // At this point the minimum level was never reached and the message level
+  // wasn't a known one; something is wrong
+  logger.error('minimumLevel of "%s" is unknown; '
+      + 'meanwhile, message level of "%s" is unknown',
+      SETTINGS.minimumLevel, messageLevel);
+
+  // Allow the message to be sent anyway
+  return true;
+}
+
+
 function addItem(item, callback) {
   if (typeof callback !== 'function') {
     callback = function dummyCallback() { return; };
@@ -304,6 +339,12 @@ function addItem(item, callback) {
     logger.log('Sending of errors is disabled');
     // reporting is disabled, so it's not an error
     // let's pretend everything is fine
+    callback();
+    return;
+  }
+
+  if (!levelGteMinimum(item)) {
+    logger.log('Item has insufficient level');
     callback();
     return;
   }


### PR DESCRIPTION
The minimumLevel option controls the minimum severity level at which messages will be reported to Rollbar.

The default is `debug`, i.e. all messages are sent.

Note that this shouldn't be merged on top of #74, since the logging is different. Pull from https://github.com/tremby/node_rollbar/tree/minimum-level-rebase instead if #74 is merged.