### PR TITLE
support for chained innerError in custom errors

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -94,20 +94,39 @@ function buildBaseData(extra) {
 
 
 function buildErrorData(baseData, err, callback) {
-  parser.parseException(err, function (e, errData) {
-    if (e) {
-      return callback(e);
-    }
-    baseData.body.trace = {
-      frames: errData.frames,
-      exception: {
-        class: errData['class'],
-        message: errData.message
-      }
-    };
+  var errors = [];
+    
+    do {
+        errors.push(err);
+    } while((err = err.innerError) !== undefined)
 
-    callback(null);
-  });
+    baseData.body.trace_chain = [];
+
+    var chain = baseData.body.trace_chain;
+    async.eachSeries(errors, function(ex, cb) {
+        
+        parser.parseException(ex, function (e, errData) {
+            if (e) {
+                if(chain.push(e) == 1) cb(e);
+            }
+                
+            chain.push({
+                frames: errData.frames,
+                exception: {
+                    class: errData['class'],
+                    message: errData.message
+                }
+            });
+
+            cb();
+        });
+
+    }, function(err) {  
+        if(err) 
+            callback(err);
+
+        callback(null); 
+    });
 }
 
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -95,38 +95,41 @@ function buildBaseData(extra) {
 
 function buildErrorData(baseData, err, callback) {
   var errors = [];
-    
-    do {
-        errors.push(err);
-    } while((err = err.innerError) !== undefined)
 
-    baseData.body.trace_chain = [];
+  do {
+    errors.push(err);
+  } while((err = err.innerError) !== undefined);
 
-    var chain = baseData.body.trace_chain;
-    async.eachSeries(errors, function(ex, cb) {
-        
-        parser.parseException(ex, function (e, errData) {
-            if (e) {
-                if(chain.push(e) == 1) cb(e);
-            }
-                
-            chain.push({
-                frames: errData.frames,
-                exception: {
-                    class: errData['class'],
-                    message: errData.message
-                }
-            });
+  baseData.body.trace_chain = [];
 
-            cb();
-        });
+  var chain = baseData.body.trace_chain;
+  async.eachSeries(errors, function(ex, cb) {
 
-    }, function(err) {  
-        if(err) 
-            callback(err);
+    parser.parseException(ex, function (e, errData) {
+      if (e) {
+        if(chain.push(e) == 1) {
+          return cb(e);
+        }
+      }
 
-        callback(null); 
+      chain.push({
+        frames: errData.frames,
+        exception: {
+          class: errData['class'],
+          message: errData.message
+        }
+      });
+
+      cb();
     });
+
+  }, function(err) {
+    if(err) {
+      callback(err);
+    } else {
+      callback(null);
+    }
+  });
 }
 
 


### PR DESCRIPTION
This pull request add support for multiple errors by posting a trace chain to rollbar. When making custom errors you may chain errors in the property innerError. To support that you have to make some changes to method buildErrorData in notifier.js and use it like this:
```javascript
var util = require('util');
var rollbar = require('rollbar');

function CustomError(ex, message) 
{
    Error.call(this);
    Error.captureStackTrace(this, this.constructor);

    this.innerError = ex;
    this.name = this.constructor.name;
    this.message = message
}
util.inherits(CustomError, Error);

rollbar.handleError( new CustomError(new Error(), "chained error") );
```