### PR TITLE
Handle uninitialized case better

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - "6"
+  - "5"
+  - "4"
   - "0.12"
   - "0.11"
   - "0.10"

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -29,11 +29,11 @@ var SETTINGS = {
     name: 'node_rollbar',
     version: exports.VERSION
   },
-  scrubHeaders: ['authorization', 'www-authorization', 'http_authorization', 'omniauth.auth', 
+  scrubHeaders: ['authorization', 'www-authorization', 'http_authorization', 'omniauth.auth',
                  'cookie', 'oauth-access-token', 'x_csrf_token', 'http_x_csrf_token', 'x-csrf-token'],
-  scrubFields: ['passwd', 'password', 'password_confirmation', 'secret', 'confirm_password', 
+  scrubFields: ['passwd', 'password', 'password_confirmation', 'secret', 'confirm_password',
                 'password_confirmation', 'secret_token', 'api_key', 'access_token', 'authenticity_token',
-                'oauth_token', 'token', 'user_session_secret', 'request.session.csrf', 
+                'oauth_token', 'token', 'user_session_secret', 'request.session.csrf',
                 'request.session._csrf', 'request.params._csrf', 'request.cookie', 'request.cookies'],
   addRequestData: null,  // Can be set by the user or will default to addRequestData defined below
   minimumLevel: 'debug',
@@ -42,6 +42,7 @@ var SETTINGS = {
 
 
 var apiClient;
+var initialized = false;
 
 
 /** Internal **/
@@ -365,12 +366,17 @@ function addItem(item, callback) {
     callback = function dummyCallback() { return; };
   }
 
-  if(!SETTINGS.enabled){
-    logger.log('Sending of errors is disabled');
+  if (!initialized) {
+    var message = 'Rollbar is not initialized';
+    logger.error(message);
+    return callback(new Error(message));
+  }
+
+  if (!SETTINGS.enabled){
+    logger.log('Rollbar is disabled');
     // reporting is disabled, so it's not an error
     // let's pretend everything is fine
-    callback();
-    return;
+    return callback();
   }
 
   if (!levelGteMinimum(item)) {
@@ -385,11 +391,14 @@ function addItem(item, callback) {
         return callback(err);
       }
 
-      apiClient.postItem(data, function (err, resp) {
-        if (typeof callback === 'function') {
+      try {
+        apiClient.postItem(data, function (err, resp) {
           callback(err, data, resp);
-        }
-      });
+        });
+      } catch (e) {
+        logger.error('Internal error while posting item: ' + e);
+        callback(e);
+      }
     });
   } catch (e) {
     logger.error('Internal error while building payload: ' + e);
@@ -440,6 +449,7 @@ exports.init = function (api, options) {
       SETTINGS[opt] = options[opt];
     }
   }
+  initialized = true;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "async": "~1.2.1"
   },
   "devDependencies": {
+    "decache": "^3.0.5",
     "express": "*",
     "jade": "~0.27.7",
-    "rewire": "^2.5.1",
     "sinon": "1.16.1",
     "vows": "~0.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "license": "MIT",
   "main": "rollbar",
   "scripts": {
-    "test": "vows --spec test/*",
-    "test-and-coverage": "istanbul cover -- vows --spec test/error.js test/json.js test/notifier.js test/parser.js test/uninitialized.js"
+    "test": "vows --spec test/*.js",
+    "test-and-coverage": "istanbul cover -- vows --spec test/*.js"
   },
   "engines": {
     "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "async": "~1.2.1"
   },
   "devDependencies": {
-    "decache": "^3.0.5",
     "express": "*",
     "jade": "~0.27.7",
     "sinon": "1.16.1",
     "vows": "~0.7.0"
+  },
+  "optionalDependencies": {
+    "decache": "^3.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "rollbar",
   "scripts": {
     "test": "vows --spec test/*",
-    "test-and-coverage": "istanbul cover -- vows --spec test/*"
+    "test-and-coverage": "istanbul cover -- vows --spec test/error.js test/json.js test/notifier.js test/parser.js test/uninitialized.js"
   },
   "engines": {
     "node": ">= 0.6.0"
@@ -30,9 +30,10 @@
     "async": "~1.2.1"
   },
   "devDependencies": {
-    "sinon": "1.16.1",
-    "jade": "~0.27.7",
     "express": "*",
+    "jade": "~0.27.7",
+    "rewire": "^2.5.1",
+    "sinon": "1.16.1",
     "vows": "~0.7.0"
   }
 }

--- a/test/uninitialized.js
+++ b/test/uninitialized.js
@@ -1,41 +1,55 @@
-var util = require('util');
-var assert = require('assert');
-var vows = require('vows');
-var decache = require('decache');
+var unsupportedNodeVersions = ['0.6', '0.8', '0.9', '0.12'];
+var version = process.version.substr(1);
+var doTest = true;
 
-var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
+for (var i = 0; i < unsupportedNodeVersions.length; ++i) {
+  if (version.indexOf(unsupportedNodeVersions[i]) === 0) {
+    console.log('Skipping uninitialized tests due to unsupported node version');
+    doTest = false;
+    break;
+  }
+}
+
+if (doTest) {
+  var util = require('util');
+  var assert = require('assert');
+  var vows = require('vows');
+  var decache = require('decache');
+
+  var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
 
 
 
-var suite = vows.describe('rollbar.reportMessage').addBatch({
-  'without init()': {
-    topic: function() {
-      decache('../lib/notifier');
-      var notifier = require('../lib/notifier');
-
-      notifier.handleError(new Error('hello world'), null, this.callback);
-    },
-
-    'should return a Rollbar uninitialized error': function(err) {
-      assert.equal(err.message, 'Rollbar is not initialized');
-    },
-
-    'now initialize and call reportMessage()': {
+  var suite = vows.describe('Uninitialized rollbar').addBatch({
+    'without init()': {
       topic: function() {
         decache('../lib/notifier');
-        decache('../lib/api');
-
         var notifier = require('../lib/notifier');
-        var api = require('../lib/api');
 
-        api.init(ACCESS_TOKEN, {});
-        notifier.init(api, {});
         notifier.handleError(new Error('hello world'), null, this.callback);
       },
 
-      'verify no error is returned': function (err) {
-        assert.isNull(err);
+      'should return a Rollbar uninitialized error': function(err) {
+        assert.equal(err.message, 'Rollbar is not initialized');
+      },
+
+      'now initialize and call reportMessage()': {
+        topic: function() {
+          decache('../lib/notifier');
+          decache('../lib/api');
+
+          var notifier = require('../lib/notifier');
+          var api = require('../lib/api');
+
+          api.init(ACCESS_TOKEN, {});
+          notifier.init(api, {});
+          notifier.handleError(new Error('hello world'), null, this.callback);
+        },
+
+        'verify no error is returned': function (err) {
+          assert.isNull(err);
+        }
       }
     }
-  }
-}).export(module, {error: false});
+  }).export(module, {error: false});
+}

--- a/test/uninitialized.js
+++ b/test/uninitialized.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var assert = require('assert');
 var vows = require('vows');
-var rewire = require('rewire');
+var decache = require('decache');
 
 var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
 
@@ -10,13 +10,10 @@ var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
 var suite = vows.describe('rollbar.reportMessage').addBatch({
   'without init()': {
     topic: function() {
-      var notifier = rewire('../lib/notifier');
+      decache('../lib/notifier');
+      var notifier = require('../lib/notifier');
 
-      var callback = this.callback;
-      notifier.__with__({initialized: false, apiClient: undefined})(function () {
-        notifier.handleError(new Error('hello world'), null, callback);
-      });
-
+      notifier.handleError(new Error('hello world'), null, this.callback);
     },
 
     'should return a Rollbar uninitialized error': function(err) {
@@ -25,8 +22,11 @@ var suite = vows.describe('rollbar.reportMessage').addBatch({
 
     'now initialize and call reportMessage()': {
       topic: function() {
-        var notifier = rewire('../lib/notifier');
-        var api = rewire('../lib/api');
+        decache('../lib/notifier');
+        decache('../lib/api');
+
+        var notifier = require('../lib/notifier');
+        var api = require('../lib/api');
 
         api.init(ACCESS_TOKEN, {});
         notifier.init(api, {});

--- a/test/uninitialized.js
+++ b/test/uninitialized.js
@@ -1,0 +1,30 @@
+var util = require('util');
+var assert = require('assert');
+var vows = require('vows');
+var rollbar = require('../rollbar');
+
+var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
+
+
+var suite = vows.describe('rollbar.reportMessage').addBatch({
+  'without init()': {
+    topic: function() {
+      rollbar.reportMessage('hello world', 'error', null, this.callback);
+    },
+
+    'should return a Rollbar uninitialized error': function(err) {
+      assert.equal(err.message, 'Rollbar is not initialized');
+    },
+
+    'now initialize and call reportMessage()': {
+      topic: function() {
+        rollbar.init(ACCESS_TOKEN);
+        rollbar.reportMessage('hello world', 'error', null, this.callback);
+      },
+
+      'verify no error is returned': function (err) {
+        assert.isNull(err);
+      }
+    }
+  }
+}).export(module, {error: false});

--- a/test/uninitialized.js
+++ b/test/uninitialized.js
@@ -1,15 +1,22 @@
 var util = require('util');
 var assert = require('assert');
 var vows = require('vows');
-var rollbar = require('../rollbar');
+var rewire = require('rewire');
 
 var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
+
 
 
 var suite = vows.describe('rollbar.reportMessage').addBatch({
   'without init()': {
     topic: function() {
-      rollbar.reportMessage('hello world', 'error', null, this.callback);
+      var notifier = rewire('../lib/notifier');
+
+      var callback = this.callback;
+      notifier.__with__({initialized: false, apiClient: undefined})(function () {
+        notifier.handleError(new Error('hello world'), null, callback);
+      });
+
     },
 
     'should return a Rollbar uninitialized error': function(err) {
@@ -18,8 +25,12 @@ var suite = vows.describe('rollbar.reportMessage').addBatch({
 
     'now initialize and call reportMessage()': {
       topic: function() {
-        rollbar.init(ACCESS_TOKEN);
-        rollbar.reportMessage('hello world', 'error', null, this.callback);
+        var notifier = rewire('../lib/notifier');
+        var api = rewire('../lib/api');
+
+        api.init(ACCESS_TOKEN, {});
+        notifier.init(api, {});
+        notifier.handleError(new Error('hello world'), null, this.callback);
       },
 
       'verify no error is returned': function (err) {


### PR DESCRIPTION
Addresses https://github.com/rollbar/node_rollbar/issues/60

If rollbar.reportMessage() or rollbar.handleError() is called before
the library is initialized we were throwing an error which was not
very descriptive. This change adds error handling for this case and
returns a useful error via the callback instead of throwing it.

@jondeandres