### PR TITLE
Added a fix for error objects where the stack might be buried

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -294,10 +294,15 @@ exports.parseException = function (exc, callback) {
 
 
 exports.parseStack = function (stack, callback) {
-  var lines;
+  var lines, _stack = stack;
+
+  // Some JS frameworks (e.g. Meteor) might bury the stack property
+  while (typeof _stack === 'object') {
+    _stack = _stack && _stack.stack;
+  }
 
   // grab all lines except the first
-  lines = (stack || '').split('\n').slice(1);
+  lines = (_stack || '').split('\n').slice(1);
 
   // Parse out all of the frame and filename info
   async.map(lines, parseFrameLine, function (err, frames) {


### PR DESCRIPTION
This fix addresses the following error I received:

```
W20161206-12:21:59.838(-8)? (STDERR) TypeError: (stack || "").split is not a function
W20161206-12:21:59.838(-8)? (STDERR)     at Object.exports.parseStack (/Volumes/SuperData/Sites/harris-partners/harris/node_modules/rollbar/lib/parser.js:300:25)
```

For some reason, the error thrown by Meteor methods had stack buried one level deeper.