### PR TITLE
do not leak scrubbed field length

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -178,7 +178,7 @@ function scrubRequestParams(params, settings) {
   settings = settings || SETTINGS;
   for (k in params) {
     if (params.hasOwnProperty(k) && params[k] && settings.scrubFields.indexOf(k) >= 0) {
-      params[k] = charFill('*', params[k].length);
+      params[k] = charFill('*', 6);
     }
   }
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -178,7 +178,7 @@ function scrubRequestParams(params, settings) {
   settings = settings || SETTINGS;
   for (k in params) {
     if (params.hasOwnProperty(k) && params[k] && settings.scrubFields.indexOf(k) >= 0) {
-      params[k] = charFill('*', 6);
+      params[k] = '******';
     }
   }
 

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -255,10 +255,11 @@ var suite = vows.describe('notifier').addBatch({
     topic: function () {
       var callback = this.callback;
       return callback(null,
-          notifier._scrubRequestParams(['nullValue', 'undefinedValue', 'emptyValue'], {
+          notifier._scrubRequestParams(['nullValue', 'undefinedValue', 'emptyValue', 'password'], {
             nullValue: null,
             undefinedValue: undefined,
             emptyValue: '',
+            password: 'Sup3rs3kr3T',
             goodValue: 'goodValue'
           }));
     },
@@ -266,6 +267,7 @@ var suite = vows.describe('notifier').addBatch({
       assert.equal(params.nullValue, null);
       assert.equal(params.undefinedValue, undefined);
       assert.equal(params.emptyValue, '');
+      assert.equal(params.password, '******');
       assert.equal(params.goodValue, 'goodValue');
     }
   },


### PR DESCRIPTION
We were inadvertently leaking information about scrubbed values (the length of the value).  Instead, always replace it with 6 asterisks. 