### PR TITLE
serialize data.context if it is an object

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -140,6 +140,19 @@ function postApi(path, payload, callback) {
 function buildPayload(data) {
   var payload;
 
+  // The API does not allow a context to be an object.  We need to detect if an
+  // object context is provided.  If so, serialize it.
+  if (typeof data.context == 'object') {
+    try {
+      data.context = JSON.stringify(data.context);
+    } catch (e) {
+      data.context = stringify(data.context);
+    }
+    if (data.context.length > 255) {
+      data.context = data.context.substr(0, 255);
+    }
+  }
+
   payload = {
     access_token: exports.accessToken,
     data: data

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -54,7 +54,7 @@ var suite = vows.describe('notifier').addBatch({
           hasContext = true;
           assert(typeof call.args[0].context == 'string');
           assert(call.args[0].context[0] == '{'); // make sure it was serialized
-          assert(call.args[0].context.length == 255); // make sure it was truncated
+          assert(call.args[0].context.length < 256); // make sure it was truncated
         }
       }
       assert(hasContext);


### PR DESCRIPTION
In response to issue #73, this patch will serialize any `data.context` that is passed in as an object.  It will also truncate it at a maximum length of 255 characters in case it's a massive object being serialized accidentally.