### PR TITLE
added support for deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **(TBD)**
 - Replace deprecated `node-uuid` package with `uuid`.  See [#102](https://github.com/rollbar/node_rollbar/pull/102) — thanks, [@gastonelhordoy](https://github.com/gastonelhordoy) !
+- Added support for Rollbar deploys. See [#57](https://github.com/rollbar/node_rollbar/issues/57)
 - Fixed a bug that accidentally exposed the length of scrubbed values.  See [#98](https://github.com/rollbar/node_rollbar/issues/98)
 - Serialize object/array values for data.context instead of throwing an error.  See [#73](https://github.com/rollbar/node_rollbar/issues/73)
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,25 @@ See the [examples](https://github.com/rollbar/node_rollbar/tree/master/examples)
 
 For a full example of setting up a new Sails.js project with Rollbar integration see [rollbar-sailsjs-example](https://github.com/rollbar/rollbar-sailsjs-example).
 
+## Deploys
+
+This implementation of the Rollbar API also contains a stand-alone implementation of
+the deploy feature.  You can require and use deploy.js without needing to fully integrate
+and configure Rollbar as described above.  This is useful for scripted implementations
+which is the most likely use case for deployment tracking.
+
+Please refer to [the Rollbar API Spec](https://rollbar.com/docs/api/deploys/) for implementation
+details and deeper explanations of the options available.
+
+```javascript
+var deploy = require('rollbar/deploy');
+
+deploy.createDeploy('POST_SERVER_ITEM_ACCESS_TOKEN', {
+    environment: 'production',
+    revision: '1.2.3'
+  });
+```
+
 ## Help / Support
 
 If you have any questions, feedback, etc., drop us a line at support@rollbar.com

--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,9 @@
+/*jslint devel: true, nomen: true, indent: 2, maxlen: 100 */
+
+"use strict";
+
+var deploy = require('./lib/deploy');
+
+exports.createDeploy = deploy.createDeploy;
+exports.getDeploy = deploy.getDeploy;
+exports.listDeploys = deploy.listDeploys;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -30,6 +30,7 @@ function handleResponse(res, callback) {
 
 function createRequestOpts(method, path, accessToken, postData) {
   var requestOpts = {
+    protocol: 'https:',
     host: 'api.rollbar.com',
     port: 443,
     path: '/api/1/'+path,
@@ -105,9 +106,13 @@ exports.getDeploy = function(accessToken, deployId, opts, callback) {
   params.push('access_token='+accessToken);
   var paramsStr = params.join('&');
 
-  https.get('https://api.rollbar.com/api/1/deploy/'+deployId+'/?'+paramsStr, function(res) {
+  var requestOpts = createRequestOpts('GET', 'deploy/'+deployId+'/?'+paramsStr, accessToken);
+
+  var req = https.request(requestOpts, function(res) {
     handleResponse(res, callback);
   });
+
+  req.end();
 };
 
 /**
@@ -132,7 +137,12 @@ exports.listDeploys = function(accessToken, pageNum, opts, callback) {
   params.push('access_token='+accessToken);
   var paramsStr = params.join('&');
 
-  https.get('https://api.rollbar.com/api/1/deploys?'+paramsStr, function(res) {
+  
+  var requestOpts = createRequestOpts('GET', 'deploys?'+paramsStr, accessToken);
+
+  var req = https.request(requestOpts, function(res) {
     handleResponse(res, callback);
   });
+
+  req.end();
 };

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,138 @@
+/*jslint devel: true, nomen: true, plusplus: true, regexp: true, indent: 2, maxlen: 100 */
+
+/*
+ *  This is an implementation of Rollbar's deploy feature.  It can be used and
+ *  required independently from the rest of the Rollbar library.  Implementation
+ *  details can be found at: https://rollbar.com/docs/api/deploys/
+ */
+
+"use strict";
+
+var https = require('https');
+var logger = require('./logger');
+
+function handleResponse(res, callback) {
+  res.setEncoding('utf8');
+  let rawData = '';
+  res.on('data', function(chunk){ rawData += chunk });
+  res.on('end', function() {
+    try {
+      let parsedData = JSON.parse(rawData);
+      if (parsedData.err) {
+        logger.error(parsedData.message);
+      }
+      callback(parsedData);
+    } catch (e) {
+      logger.error(e);
+    }
+  });
+};
+
+function createRequestOpts(method, path, accessToken, postData) {
+  var requestOpts = {
+    host: 'api.rollbar.com',
+    port: 443,
+    path: '/api/1/'+path,
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Rollbar-Access-Token': accessToken
+    }
+  };
+
+  if (postData) {
+    requestOpts.headers['Content-Length'] = Buffer.byteLength(postData);
+  }
+
+  return requestOpts;
+};
+
+/**
+ * Create a deploy entry.
+ * This is an implementation of the API specified at:
+ * https://rollbar.com/docs/api/deploys/#record-create-a-deploy
+ *
+ * @param accessToken - A post_server_item-scope project access token.
+ * @param params - An object with some required and optional parameters
+ *          environment:  Required. Name of the environment being deployed. (String up to 255 chars)
+ *          revision: Required. String identifying the revision being deployed, such as a Git SHA. (String up to 255 chars). This param can also be provided under the name head_long.
+ *          rollbar_username: Rollbar username of the user who deployed.
+ *          local_username: Username (on your system) who deployed. (String up to 255 chars)
+ *          comment: Additional text data to record with this deploy. (String up to 64kb)
+ * @param opts - An object with connection options.
+ * @param callback
+ */
+exports.createDeploy = function(accessToken, params, opts, callback) {
+  if (typeof callback != 'function')
+    callback = function(){};
+
+  var requestOpts = createRequestOpts('POST', 'deploy/', accessToken);
+
+  var req = https.request(requestOpts, function(res) {
+    handleResponse(res, callback);
+  });
+
+  var writeData = {};
+  try {
+    try {
+      writeData = JSON.stringify(params);
+    } catch (e) {
+      writedata = stringify(params);
+    }
+  } catch (e) {
+    logger.error('Could not safe-stringify data.  Giving up');
+    return callback(e);
+  }
+  req.write(writeData);
+  req.end();
+};
+
+/**
+ * Retrieve a single deploy entry using an ID.
+ * This is an implementation of the API specified at:
+ * https://rollbar.com/docs/api/deploys/#get-a-deploy-by-id
+ *
+ * @param accessToken - Required. A read-scope project access token.
+ * @param deployId - Required.  The ID to fetch.
+ * @param opts - An object with connection options
+ * @param callback
+ */
+exports.getDeploy = function(accessToken, deployId, opts, callback) {
+  if (typeof callback != 'function')
+    callback = function(){};
+
+  var params = [];
+  params.push('access_token='+accessToken);
+  var paramsStr = params.join('&');
+
+  https.get('https://api.rollbar.com/api/1/deploy/'+deployId+'/?'+paramsStr, function(res) {
+    handleResponse(res, callback);
+  });
+};
+
+/**
+ * Retrieve a list of deploys.
+ * This is an implementation of the API specified at:
+ * https://rollbar.com/docs/api/deploys/#list-all-deploys
+ *
+ * @param accessToken - Required. A read-scope project access token.
+ * @param pageNum - An integer page number >= 1.  If not specified, 1 will be used.
+ * @param opts - An object with connection options.
+ * @param callback
+ */
+exports.listDeploys = function(accessToken, pageNum, opts, callback) {
+  if (typeof pageNum != 'number' || pageNum < 1)
+    pageNum = 1;
+
+  if (typeof callback != 'function')
+    callback = function(){};
+
+  var params = [];
+  params.push('page='+pageNum);
+  params.push('access_token='+accessToken);
+  var paramsStr = params.join('&');
+
+  https.get('https://api.rollbar.com/api/1/deploys?'+paramsStr, function(res) {
+    handleResponse(res, callback);
+  });
+};

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -13,11 +13,11 @@ var logger = require('./logger');
 
 function handleResponse(res, callback) {
   res.setEncoding('utf8');
-  let rawData = '';
+  var rawData = '';
   res.on('data', function(chunk){ rawData += chunk });
   res.on('end', function() {
     try {
-      let parsedData = JSON.parse(rawData);
+      var parsedData = JSON.parse(rawData);
       if (parsedData.err) {
         logger.error(parsedData.message);
       }

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -1,0 +1,63 @@
+/*jslint devel: true, node: true, nomen: true, plusplus: true, indent: 2, maxlen: 100 */
+
+"use strict";
+
+var assert = require('assert');
+var vows = require('vows');
+var sinon = require('sinon');
+
+var deploy = require('../deploy');
+
+var ACCESS_TOKEN = '8802be7c990a4922beadaaefb6e0327b';
+var READ_TOKEN = '5bd281baadec492fbf5e443e82d0fc20';
+
+// sinon.spy(api, 'postItem');
+
+var suite = vows.describe('deploy').addBatch({
+
+  'creating a deploy without the correct parameters': {
+    topic: function () {
+      deploy.createDeploy(ACCESS_TOKEN, {}, {}, this.callback);
+    },
+    'verify that the correct validation occurs': function (response) {
+      assert.match(response.message, /Missing 'environment'/);
+      assert.match(response.message, /Missing 'revision'/);
+    }
+  },
+
+  'creating a deploy with the correct parameters': {
+    topic: function () {
+      deploy.createDeploy(ACCESS_TOKEN, {environment: 'production', revision: '123'}, {}, this.callback);
+    },
+    'verify that no errors were thrown': function (response) {
+      assert.deepEqual(response.data, {});
+    }
+  },
+
+
+  'listing an error is thrown without the correct token': {
+    topic: function () {
+      deploy.listDeploys(ACCESS_TOKEN, 1, {}, this.callback);
+    },
+    'verify that a page of deploys is returned': function (response) {
+      assert.match(response.message, /insufficient privileges/);
+    }
+  },
+
+  'listing a page of deploys and retrieving a single deploy': {
+    topic: function () {
+      var cb = this.callback;
+      deploy.listDeploys(READ_TOKEN, 1, {}, function(listResponse) {
+        deploy.getDeploy(READ_TOKEN, listResponse.result.deploys[0].id, {}, function(getResponse) {
+          cb(listResponse, getResponse);
+        });
+      });
+    },
+    'verify that a page of deploys is returned': function (listResponse, getResponse) {
+      assert(listResponse.result.deploys.length > 1);
+      assert(getResponse.result.id);
+      assert(getResponse.result.start_time);
+    }
+  }
+
+}).export(module, {error: false});


### PR DESCRIPTION
This adds support for Rollbar deploys to the node package.  It is an implementation of the API spec found at https://rollbar.com/docs/api/deploys/, and requested in #57.