### PR TITLE
[#104] use request-ip to extract ip address from request

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -9,6 +9,7 @@ var https = require('https');
 var uuidV4 = require('uuid/v4');
 var os = require('os');
 var url = require('url');
+var requestIp = require('request-ip');
 
 var parser = require('./parser');
 var packageJson = require('../package.json');
@@ -191,11 +192,23 @@ function scrubRequestParams(params, settings) {
 function extractIp(req) {
   var ip = req.ip;
   if (!ip) {
-    if (req.headers) {
-      ip = req.headers['x-real-ip'] || req.headers['x-forwarded-for'];
-    }
-    if (!ip && req.connection && req.connection.remoteAddress) {
-      ip = req.connection.remoteAddress;
+    try {
+      ip = requestIp.getClientIp(req)
+    } catch (error) {
+      // we might get here if req.headers is undefined. in that case go ahead and
+      // walk through the various attributes of req that might contain an address
+      // (request-ip will do this for us but wouldn't have gotten this far if
+      // headers were undefined so we do it manually using the same logic from:
+      // https://github.com/pbojinov/request-ip/blob/master/index.js#L36)
+      if (req.connection && req.connection.remoteAddress) {
+        ip = req.connection.remoteAddress;
+      } else if (req.socket && req.socket.remoteAddress) {
+        ip = req.socket.remoteAddress;
+      } else if (req.connection && req.connection.socket && req.connection.socket.remoteAddress) {
+        ip = req.connection.socket.remoteAddress;
+      } else if (req.info && req.info.remoteAddress) {
+        ip = req.info.remoteAddress;
+      }
     }
   }
   return ip;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "2.2.0",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",
-    "request-ip": "^1.2.3",
+    "request-ip": "~1.2.3",
     "uuid": "3.0.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "uuid": "3.0.x",
-    "lru-cache": "~2.2.1",
+    "async": "~1.2.1",
     "debug": "2.2.0",
     "json-stringify-safe": "~5.0.0",
-    "async": "~1.2.1"
+    "lru-cache": "~2.2.1",
+    "request-ip": "^1.2.3",
+    "uuid": "3.0.x"
   },
   "devDependencies": {
     "express": "*",

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -366,7 +366,6 @@ vows.describe('notifier').addBatch({
       var dummyReq = {
         headers: {
           'x-real-ip': 'X-Real-Ip IP address',
-          'x-forwarded-for': 'X-Forwarded-For IP address'
         },
         connection: {
           remoteAddress: 'Connection IP address'
@@ -378,7 +377,7 @@ vows.describe('notifier').addBatch({
       assert.equal(ip, 'X-Real-Ip IP address');
     }
   },
-  'extractIp returns req.header["x-forwarded-for"] if x-real-ip doesn\'t exist': {
+  'extractIp returns req.header["x-forwarded-for"] if req.ip doesn\'t exist': {
     topic: function () {
       var dummyReq = {
         headers: {
@@ -394,11 +393,9 @@ vows.describe('notifier').addBatch({
       assert.equal(ip, 'X-Forwarded-For IP address');
     }
   },
-  'extractIp returns req.connection.remoteAddress x-forwarded-for doesn\'t exist': {
+  'extractIp returns req.connection.remoteAddress without ip headers': {
     topic: function () {
       var dummyReq = {
-        headers: {
-        },
         connection: {
           remoteAddress: 'Connection IP address'
         }
@@ -409,7 +406,48 @@ vows.describe('notifier').addBatch({
       assert.equal(ip, 'Connection IP address');
     }
   },
-  'extractIp doesn\'t crash if req.connection/req.headers doesn\'t exist': {
+  'extractIp returns req.socket.remoteAddress without ip headers': {
+    topic: function () {
+      var dummyReq = {
+        socket: {
+          remoteAddress: 'Connection IP address'
+        }
+      };
+      return this.callback(notifier._extractIp(dummyReq));
+    },
+    'verify the IP': function (ip) {
+      assert.equal(ip, 'Connection IP address');
+    }
+  },
+  'extractIp returns req.connection.socket.remoteAddress without ip headers': {
+    topic: function () {
+      var dummyReq = {
+        connection: {
+          socket: {
+            remoteAddress: 'Connection IP address'
+          }
+        },
+      };
+      return this.callback(notifier._extractIp(dummyReq));
+    },
+    'verify the IP': function (ip) {
+      assert.equal(ip, 'Connection IP address');
+    }
+  },
+  'extractIp returns req.info.remoteAddress without ip headers': {
+    topic: function () {
+      var dummyReq = {
+        info: {
+          remoteAddress: 'Connection IP address'
+        },
+      };
+      return this.callback(notifier._extractIp(dummyReq));
+    },
+    'verify the IP': function (ip) {
+      assert.equal(ip, 'Connection IP address');
+    }
+  },
+  'extractIp doesn\'t crash if req.connection/req.info/req.socket/req.headers doesn\'t exist': {
     topic: function () {
       var dummyReq = {};
       return this.callback(notifier._extractIp(dummyReq));


### PR DESCRIPTION
note: previously `x-real-ip` was taking precedence over `x-forwarded-for` but in this change it's not - i don't know if there was a specific reason for that but i can't find any other examples of doing this since it doesn't seem to handle the case where multiple proxies process a single request. 