### PR TITLE
Added a wait() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug that accidentally exposed the length of scrubbed values.  See [#98](https://github.com/rollbar/node_rollbar/issues/98)
 - Serialize object/array values for data.context instead of throwing an error.  See [#73](https://github.com/rollbar/node_rollbar/issues/73)
 - Added the `retryInterval` option.  In the event of a connection failure, queue up errors and push them to the Rollbar API later.  See [#49](https://github.com/rollbar/node_rollbar/issues/49)
+- Added a `wait(cb)` function that executes the callback when there are no pending items in flight being sent to Rollbar [#39](https://github.com/rollbar/node_rollbar/issues/39) 
 
 **0.6.3**
 - Fix a bug which caused the exception class to not be properly reported. See [#95](https://github.com/rollbar/node_rollbar/pull/95), [#96](https://github.com/rollbar/node_rollbar/pull/96)

--- a/README.md
+++ b/README.md
@@ -391,6 +391,23 @@ doPurchase({
 });
 ```
 
+## Waiting on pending items
+
+There may be some cases where you need to do a hard `process.exit(1)`, but you also don't
+want to lose any errors that may be in-flight to Rollbar at the time.  That is where the
+`notifier.wait(cb)` function comes into play.  It will execute the callback when there are
+no pending items being sent to Rollbar.  It could execute immediately (if there are none
+pending), or it could take a few seconds while the queue is flushed.
+
+```javascript
+var rollbar = require('rollbar');
+rollbar.init(rollbarToken);
+rollbar.handleError('Test');
+rollbar.wait(function() {
+    console.log('Ok!  All errors have been pushed to Rollbar.');
+    process.exit(1);
+  });
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ doPurchase({
 
 There may be some cases where you need to do a hard `process.exit(1)`, but you also don't
 want to lose any errors that may be in-flight to Rollbar at the time.  That is where the
-`notifier.wait(cb)` function comes into play.  It will execute the callback when there are
+`rollbar.wait(cb)` function comes into play.  It will execute the callback when there are
 no pending items being sent to Rollbar.  It could execute immediately (if there are none
 pending), or it could take a few seconds while the queue is flushed.
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -24,7 +24,6 @@ var SETTINGS = {
 };
 
 var retryQueue = [];
-var pendingQueue = [];
 var retryHandle = null;
 
 
@@ -89,15 +88,6 @@ function retryApiRequest(args) {
   }
 }
 
-function dequeueApiRequest(req) {
-  for (var i=0; i < pendingQueue.length; i++) {
-    if (pendingQueue[i] == req) {
-      pendingQueue.splice(i, 1);
-      return;
-    }
-  }
-}
-
 function makeApiRequest(args) {
   var writeData, req;
   var transport = args.transport;
@@ -146,15 +136,9 @@ function makeApiRequest(args) {
       respData = respData.join('');
       parseApiResponse(respData, callback);
     });
-
-    dequeueApiRequest(req);
   });
 
-  pendingQueue.push(req);
-
   req.on('error', function (err) {
-    dequeueApiRequest(req);
-
     // If the request to Rollbar failed due to a connection error, lets queue
     // up the requests and try again periodically in the hopes that the connection
     // will be restored.
@@ -259,9 +243,4 @@ exports.init = function (accessToken, options) {
 
 exports.postItem = function (item, callback) {
   return postApi('item/', buildPayload(item), callback);
-};
-
-
-exports.pendingRequestCount = function() {
-  return pendingQueue.length;
 };

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -45,7 +45,7 @@ var SETTINGS = {
 
 var apiClient;
 var initialized = false;
-
+var pendingItems = [];
 
 /** Internal **/
 
@@ -388,6 +388,9 @@ function addItem(item, callback) {
   }
 
   try {
+    var pendingItem = {item:item, req:null};
+    pendingItems.push(pendingItem);
+
     buildItemData(item, function (err, data) {
       if (err) {
         return callback(err);
@@ -395,9 +398,11 @@ function addItem(item, callback) {
 
       try {
         apiClient.postItem(data, function (err, resp) {
+          dequeuePendingItem(pendingItem)
           callback(err, data, resp);
         });
       } catch (e) {
+        dequeuePendingItem(pendingItem)
         logger.error('Internal error while posting item: ' + e);
         callback(e);
       }
@@ -408,6 +413,19 @@ function addItem(item, callback) {
   }
 }
 
+
+/*
+ * This will remove a pendingItem entry from the queue.  This should be called
+ * either when there is an error, or when the item was sent successfully.
+ */
+function dequeuePendingItem(pendingItem) {
+  for (var i=0; i < pendingItems.length; i++) {
+    if (pendingItems[i] == pendingItem) {
+      pendingItems.splice(i, 1);
+      return;
+    }
+  }
+}
 
 /*
  * Exports for testing
@@ -452,6 +470,11 @@ exports.init = function (api, options) {
     }
   }
   initialized = true;
+};
+
+
+exports.pendingItemsCount = function() {
+  return pendingItems.length;
 };
 
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -407,6 +407,7 @@ function addItem(item, callback) {
 
     buildItemData(item, function (err, data) {
       if (err) {
+        dequeuePendingItem(pendingItem);
         return callback(err);
       }
 
@@ -422,6 +423,7 @@ function addItem(item, callback) {
       }
     });
   } catch (e) {
+    dequeuePendingItem(pendingItem);
     logger.error('Internal error while building payload: ' + e);
     callback(e);
   }

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -46,6 +46,7 @@ var SETTINGS = {
 var apiClient;
 var initialized = false;
 var pendingItems = [];
+var shutdownCallback = null;
 
 /** Internal **/
 
@@ -398,11 +399,11 @@ function addItem(item, callback) {
 
       try {
         apiClient.postItem(data, function (err, resp) {
-          dequeuePendingItem(pendingItem)
+          dequeuePendingItem(pendingItem);
           callback(err, data, resp);
         });
       } catch (e) {
-        dequeuePendingItem(pendingItem)
+        dequeuePendingItem(pendingItem);
         logger.error('Internal error while posting item: ' + e);
         callback(e);
       }
@@ -422,6 +423,13 @@ function dequeuePendingItem(pendingItem) {
   for (var i=0; i < pendingItems.length; i++) {
     if (pendingItems[i] == pendingItem) {
       pendingItems.splice(i, 1);
+
+      // If there is a registered shutdown callback, and we've reached the end
+      // of the pendingItem queue, then call that callback.
+      if (typeof shutdownCallback === 'function' && exports.pendingItemsCount() === 0) {
+        shutdownCallback();
+      }
+
       return;
     }
   }
@@ -475,6 +483,21 @@ exports.init = function (api, options) {
 
 exports.pendingItemsCount = function() {
   return pendingItems.length;
+};
+
+
+/*
+ * This registers a shutdown callback.  This callback will be called
+ * when there are 0 pendingItems enqueued.  It could be called immediately
+ * if there are none pending right now.  Or if there are pending items
+ * then it will be called when the pendingItem queue becomes empty.
+ */
+exports.shutdown = function(callback) {
+  if (exports.pendingItemsCount() === 0) {
+    callback();
+  } else {
+    shutdownCallback = callback;
+  }
 };
 
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -46,7 +46,7 @@ var SETTINGS = {
 var apiClient;
 var initialized = false;
 var pendingItems = [];
-var shutdownCallback = null;
+var waitCallback = null;
 
 /** Internal **/
 
@@ -424,10 +424,10 @@ function dequeuePendingItem(pendingItem) {
     if (pendingItems[i] == pendingItem) {
       pendingItems.splice(i, 1);
 
-      // If there is a registered shutdown callback, and we've reached the end
+      // If there is a registered wait callback, and we've reached the end
       // of the pendingItem queue, then call that callback.
-      if (typeof shutdownCallback === 'function' && exports.pendingItemsCount() === 0) {
-        shutdownCallback();
+      if (typeof waitCallback === 'function' && exports.pendingItemsCount() === 0) {
+        waitCallback();
       }
 
       return;
@@ -487,16 +487,16 @@ exports.pendingItemsCount = function() {
 
 
 /*
- * This registers a shutdown callback.  This callback will be called
+ * This registers a wait callback.  This callback will be called
  * when there are 0 pendingItems enqueued.  It could be called immediately
  * if there are none pending right now.  Or if there are pending items
  * then it will be called when the pendingItem queue becomes empty.
  */
-exports.shutdown = function(callback) {
+exports.wait = function(callback) {
   if (exports.pendingItemsCount() === 0) {
     callback();
   } else {
-    shutdownCallback = callback;
+    waitCallback = callback;
   }
 };
 

--- a/rollbar.js
+++ b/rollbar.js
@@ -305,7 +305,7 @@ exports.handleUnhandledRejections = function (accessToken, options) {
   }
 };
 
-
+exports.wait = notifier.wait;
 
 exports.api = api;
 exports.notifier = notifier;

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -46,25 +46,25 @@ vows.describe('notifier pending requests').addBatch({
   }
 }).export(module, {error: false});
 
-var shutdownSandbox = null;
-vows.describe('notifier shutdown').addBatch({
+var waitSandbox = null;
+vows.describe('notifier wait').addBatch({
   'has pending requests': {
     topic: function() {
       assert(notifier.pendingItemsCount() == 0);
-      shutdownSandbox = sinon.sandbox.create();
-      shutdownSandbox.stub(https, 'request', function(){ /* do nothing */ });
+      waitSandbox = sinon.sandbox.create();
+      waitSandbox.stub(https, 'request', function(){ /* do nothing */ });
 
       notifier.handleError(new Error('test'));
       assert(notifier.pendingItemsCount() == 1); // should have been enqueued synchronously
 
-      notifier.shutdown(this.callback);
+      notifier.wait(this.callback);
 
       notifier.handleError(new Error('test'));
       assert(notifier.pendingItemsCount() == 2); // should have been enqueued synchronously
     },
     'it keeps track of pending requests': function() {
       assert(notifier.pendingItemsCount() == 0); // callback should be called after all items are flushed
-      shutdownSandbox.restore();
+      waitSandbox.restore();
     }
   }
 }).export(module, {error: false});

--- a/test/notifier.js
+++ b/test/notifier.js
@@ -33,13 +33,14 @@ var sandbox = null;
 vows.describe('notifier pending requests').addBatch({
   'pending requests': {
     topic: function() {
-      assert(api.pendingRequestCount() == 0);
+      assert(notifier.pendingItemsCount() == 0);
       sandbox = sinon.sandbox.create();
       sandbox.stub(https, 'request', function(){ /* do nothing */ });
       notifier.handleError(new Error('test'), this.callback);
+      assert(notifier.pendingItemsCount() == 1); // should have been enqueued synchronously
     },
     'it keeps track of pending requests': function() {
-      assert(api.pendingRequestCount() == 1);
+      assert(notifier.pendingItemsCount() == 0); // should have been dequeued before callback is called
       sandbox.restore();
     }
   }


### PR DESCRIPTION
This PR is in response to #39.  This adds a `wait(cb)` function that executes the callback after there are no more pending items being sent to Rollbar.  I called the function `wait` instead of the suggested `shutdown` because it's more descriptive of the actual functionality.  The function doesn't actually shut anything down; it just executes a callback when there is nothing in flight.