### PR TITLE
Fixed directing output to stdout

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,12 +5,12 @@
 var debug = require('debug');
 var name = 'Rollbar';
 
+// Enable output to stdout
+debug.enable(name + ':log,' + name + ':error');
+
 var logger = {
   log: debug(name + ':log'),
   error: debug(name + ':error')
 };
-
-// Make logger.log log to stdout rather than stderr
-logger.log.log = console.log.bind(console);
 
 module.exports = logger;


### PR DESCRIPTION
There's been a weird hack in the code trying to redirect output to console. It didn't work at my environment. I read the debug library code & docs for the version number which is used here and added the code to properly enable output to stdout.